### PR TITLE
[fix] 노트 삭제 API 수정

### DIFF
--- a/src/main/java/trackers/demo/chat/domain/ChatRoom.java
+++ b/src/main/java/trackers/demo/chat/domain/ChatRoom.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import trackers.demo.global.common.entity.BaseTimeEntity;
 import trackers.demo.member.domain.Member;
 import trackers.demo.note.domain.Note;
@@ -20,6 +22,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = PROTECTED)
+
 public class ChatRoom extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/trackers/demo/chat/service/ChatService.java
+++ b/src/main/java/trackers/demo/chat/service/ChatService.java
@@ -56,7 +56,6 @@ public class ChatService {
     public List<ChatRoomResponse> getChatRooms(final Long memberId) {
         final List<ChatRoom> chatRooms = chatRoomRepository.findByMemberId(memberId);
 
-
         return chatRooms.stream()
                 .map(ChatRoomResponse::of)
                 .collect(Collectors.toList());

--- a/src/main/java/trackers/demo/note/domain/repository/NoteRepository.java
+++ b/src/main/java/trackers/demo/note/domain/repository/NoteRepository.java
@@ -1,6 +1,7 @@
 package trackers.demo.note.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import trackers.demo.note.domain.Note;
@@ -8,5 +9,9 @@ import trackers.demo.note.domain.Note;
 public interface NoteRepository extends JpaRepository<Note, Long> {
 
     Note findByChatRoomId(final Long chatRoomId);
+
+    @Modifying
+    @Query("UPDATE Note n SET n.status = 'DELETED' WHERE n.id = :noteId")
+    void deleteById(final Long noteId);
 
 }

--- a/src/main/java/trackers/demo/note/presentation/NoteController.java
+++ b/src/main/java/trackers/demo/note/presentation/NoteController.java
@@ -47,9 +47,9 @@ public class NoteController {
             @Auth final Accessor accessor,
             @PathVariable("noteId") final Long noteId
     ){
-        log.info("memberId={}의 요약 노트 삭제 요청이 들어왔습니다.", accessor.getMemberId());
+        log.info("memberId={}의 noteId ={}의 삭제 요청이 들어왔습니다.", accessor.getMemberId(), noteId);
         noteService.validateNoteByMemberId(accessor.getMemberId(), noteId);
-        noteService.deleteNote(noteId);
+        noteService.delete(noteId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/trackers/demo/note/service/NoteService.java
+++ b/src/main/java/trackers/demo/note/service/NoteService.java
@@ -4,20 +4,17 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import trackers.demo.admin.domain.Assistant;
 import trackers.demo.admin.domain.repository.AssistantRepository;
 import trackers.demo.chat.domain.ChatRoom;
 import trackers.demo.chat.domain.repository.ChatRoomRepository;
 import trackers.demo.global.config.ChatGPTConfig;
 import trackers.demo.global.exception.BadRequestException;
-import trackers.demo.global.exception.ExceptionCode;
 import trackers.demo.note.domain.Note;
 import trackers.demo.note.domain.repository.CustomNoteRepository;
 import trackers.demo.note.domain.repository.NoteRepository;
 import trackers.demo.note.dto.response.DetailNoteResponse;
 import trackers.demo.note.dto.response.SimpleNoteResponse;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -64,6 +61,5 @@ public class NoteService {
         return DetailNoteResponse.of(note);
     }
 
-
-    public void deleteNote(Long noteId) { noteRepository.deleteById(noteId); }
+    public void delete(final Long noteId) { noteRepository.deleteById(noteId); }
 }

--- a/src/main/java/trackers/demo/project/service/ProjectService.java
+++ b/src/main/java/trackers/demo/project/service/ProjectService.java
@@ -246,9 +246,6 @@ public class ProjectService {
     }
 
     public void delete(final Long projectId) {
-        if(!projectRepository.existsById(projectId)) {
-            throw new BadRequestException(NOT_FOUND_PROJECT);
-        }
         projectTargetRepository.deleteByProjectId(projectId);
         projectTagRepository.deleteAllByProjectId(projectId);
         projectRepository.deleteById(projectId);

--- a/src/test/java/trackers/demo/note/presentation/NoteControllerTest.java
+++ b/src/test/java/trackers/demo/note/presentation/NoteControllerTest.java
@@ -15,8 +15,6 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
-import trackers.demo.chat.presentation.ChatController;
-import trackers.demo.chat.service.ChatService;
 import trackers.demo.global.ControllerTest;
 import trackers.demo.loginv2.domain.MemberTokens;
 import trackers.demo.note.dto.response.DetailNoteResponse;
@@ -42,7 +40,6 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static trackers.demo.chat.fixture.ChatFixture.*;
 import static trackers.demo.global.restdocs.RestDocsConfiguration.field;
 import static trackers.demo.note.presentation.fixture.NoteFixture.*;
 
@@ -178,7 +175,7 @@ public class NoteControllerTest extends ControllerTest {
         final ResultActions resultActions = performDeleteRequest();
 
         // then
-        verify(noteService).deleteNote(anyLong());
+        verify(noteService).delete(anyLong());
 
         resultActions.andExpect(status().isNoContent())
                 .andDo(restDocs.document(


### PR DESCRIPTION
### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 테스트
- [ ] 기능 삭제
- [ ✅  버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 👀 반영 브랜치
ex) feat/project -> dev

### 💻 변경 사항
ex) 노트 삭제 API에서 JPQL을 사용하여 명시적으로 프로젝트의 상태를 deleted로 변경

### 🙏 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.