### PR TITLE
[fix] 노트 내역 조회 API 수정

### DIFF
--- a/src/main/java/trackers/demo/note/domain/repository/NoteRepository.java
+++ b/src/main/java/trackers/demo/note/domain/repository/NoteRepository.java
@@ -10,8 +10,6 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
 
     Note findByChatRoomId(final Long chatRoomId);
 
-    @Modifying
-    @Query("UPDATE Note n SET n.status = 'DELETED' WHERE n.id = :noteId")
     void deleteById(final Long noteId);
 
 }

--- a/src/main/java/trackers/demo/note/service/NoteService.java
+++ b/src/main/java/trackers/demo/note/service/NoteService.java
@@ -16,6 +16,7 @@ import trackers.demo.note.dto.response.DetailNoteResponse;
 import trackers.demo.note.dto.response.SimpleNoteResponse;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static trackers.demo.global.exception.ExceptionCode.*;
@@ -39,6 +40,7 @@ public class NoteService {
 
         final List<Note> notes = chatRooms.stream()
                 .map(chatRoom -> noteRepository.findByChatRoomId(chatRoom.getId()))
+                .filter(Objects::nonNull)
                 .toList();
 
         return notes.stream()
@@ -47,8 +49,11 @@ public class NoteService {
     }
 
     public void validateNoteByMemberId(final Long memberId, final Long noteId) {
-        final ChatRoom chatRoom = chatRoomRepository.findByNoteId(noteId)
-                .orElseThrow(() -> new BadRequestException(NOT_FOUND_CHAT_ROOM));
+        final Note note = noteRepository.findById(noteId)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_NOTE));
+
+        final ChatRoom chatRoom = note.getChatRoom();
+
         if(!chatRoomRepository.existsByMemberIdAndId(memberId, chatRoom.getId())) {
             throw new BadRequestException(NOT_FOUND_NOTE_BY_MEMBER_ID);
         }
@@ -61,5 +66,7 @@ public class NoteService {
         return DetailNoteResponse.of(note);
     }
 
-    public void delete(final Long noteId) { noteRepository.deleteById(noteId); }
+    public void delete(final Long noteId) {
+        noteRepository.deleteById(noteId);
+    }
 }


### PR DESCRIPTION
### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 테스트
- [ ] 기능 삭제
- [✅] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 👀 반영 브랜치
ex) feat/project -> dev

### 💻 변경 사항
1. 요약 노트 삭제 API에서 영속성 컨텍스트를 고려해서 삭제 쿼리가 안나가는 문제 해결
2. 요약 노트 내역 조회 API에서 null인 Note를 조회하지 않도록 필터링

### 🙏 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.