### PR TITLE
[fix] 기획서 자동완성하기 API 수정

### DIFF
--- a/src/docs/asciidoc/docs.adoc
+++ b/src/docs/asciidoc/docs.adoc
@@ -118,7 +118,7 @@ include::{snippets}/note-controller-test/delete-note/path-parameters.adoc[]
 ==== 응답
 include::{snippets}/note-controller-test/delete-note/http-response.adoc[]
 
-=== 3.4 기획서 자동 완성하기 ( GET /note/:noteId/completion )
+=== 3.4 기획서 자동 완성하기 ( POST /note/:noteId/completion )
 ==== 요청
 include::{snippets}/note-controller-test/get-automated-proposal/http-request.adoc[]
 include::{snippets}/note-controller-test/get-automated-proposal/path-parameters.adoc[]

--- a/src/main/java/trackers/demo/chat/service/ChatService.java
+++ b/src/main/java/trackers/demo/chat/service/ChatService.java
@@ -293,7 +293,8 @@ public class ChatService {
     private SuccessResponse createNewNote(final String receivedMessage, final ChatRoom chatRoom) throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
 
-        final String trimmedMessage = receivedMessage.replace("```json", "").replace("```", "").trim();
+        final String trimmedMessage = receivedMessage.replaceAll(".*(\\{.*\\}).*", "$1");
+
         log.info("정제 전 요약 응답: {}", receivedMessage);
         log.info("정제 후 요약 응답: {}", trimmedMessage);
 

--- a/src/main/java/trackers/demo/note/presentation/NoteController.java
+++ b/src/main/java/trackers/demo/note/presentation/NoteController.java
@@ -55,7 +55,7 @@ public class NoteController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/{noteId}/completion")
+    @PostMapping("/{noteId}/completion")
     @MemberOnly
     public ResponseEntity<ProjectProposalResponse> getAutomatedProposal(
             @Auth final Accessor accessor,

--- a/src/main/java/trackers/demo/note/service/NoteService.java
+++ b/src/main/java/trackers/demo/note/service/NoteService.java
@@ -33,6 +33,7 @@ import trackers.demo.project.domain.repository.ProjectRepository;
 import trackers.demo.project.domain.repository.ProjectTargetRepository;
 import trackers.demo.project.domain.repository.TargetRepository;
 
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -239,16 +240,19 @@ public class NoteService {
     ) throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
 
+        final String trimmedMessage = receivedMessage.replaceAll(".*(\\{.*\\}).*", "$1");
+
         log.info("정제 전 기획서 응답: {}", receivedMessage);
-        // todo : 정제 작업
+        log.info("정제 후 기획서 응답: {}", trimmedMessage);
 
         final AutomatedProposalResponse automatedProposalResponse
-                = objectMapper.readValue(receivedMessage, AutomatedProposalResponse.class);
+                = objectMapper.readValue(trimmedMessage, AutomatedProposalResponse.class);
 
-        // todo : 프로젝트 저장
         final Project project = Project.createProject(
                 member,
                 note.getProblem(),
+                LocalDate.now(),
+                LocalDate.now().plusDays(100),
                 note.getTitle(),
                 automatedProposalResponse.getTitleList(),
                 automatedProposalResponse.getContentList()

--- a/src/main/java/trackers/demo/project/domain/Project.java
+++ b/src/main/java/trackers/demo/project/domain/Project.java
@@ -35,7 +35,7 @@ public class Project extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 30)
     private String summary;     // 사회 문제 요약
 
     @Column(nullable = false)
@@ -44,10 +44,10 @@ public class Project extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDate endDate;  // 프로젝트 마감 날짜
 
-    @Column(length = 50, nullable = false)
+    @Column(nullable = false, length = 50)
     private String projectTitle;    // 프로젝트명
 
-    @Column(nullable = false)
+    @Column(length = 100)
     private String mainImagePath;   // 대표 사진
 
     @Column(length = 180)
@@ -95,6 +95,8 @@ public class Project extends BaseTimeEntity {
     public static Project createProject(
             final Member member,
             final String summary,
+            final LocalDate startDate,
+            final LocalDate endDate,
             final String projectTitle,
             final List<String> subTitleList,
             final List<String> contentList
@@ -103,8 +105,8 @@ public class Project extends BaseTimeEntity {
                 null,
                 member,
                 summary,
-                null,
-                null,
+                startDate,
+                endDate,
                 projectTitle,
                 null,
                 subTitleList,

--- a/src/main/java/trackers/demo/project/dto/request/ProjectUpdateBodyRequest.java
+++ b/src/main/java/trackers/demo/project/dto/request/ProjectUpdateBodyRequest.java
@@ -19,12 +19,10 @@ public class ProjectUpdateBodyRequest {
     @Size(max = 3, message = "본문은 최대 3개 입니다")
     private final List<String> contentList;
 
-    @NotNull(message = "변경 사항이 없는 이미지 URL을 입력해주세요")
-    @Size(max = 3, message = "이미지는 최대 10개 입니다")
+    @Size(max = 10, message = "변경 사항이 없는 이미지 URL을 입력해주세요, 이미지는 최대 10개 입니다")
     private final List<String> projectImageList;
 
     @Size(max = 10, message = "변경된 태그들을 입력해주세요.(최대 10개)")
     private final List<String> tagList;
-
 
 }

--- a/src/main/java/trackers/demo/project/presentation/ProjectController.java
+++ b/src/main/java/trackers/demo/project/presentation/ProjectController.java
@@ -39,7 +39,6 @@ public class ProjectController {
             @RequestPart(value = "dto") @Valid final ProjectCreateOutlineRequest createRequest,
             @RequestPart(value = "file") final MultipartFile mainImage
             ){
-        // 원자성 문제가 생길 수 있음 -> try-catch 문으로 해결 예정
         log.info("memberId={}의 프로젝트 개요 저장 요청이 들어왔습니다.", accessor.getMemberId());
         final String imageUrl = imageService.saveImage(mainImage);
         final Long projectId = projectService.saveProjectOutline(accessor.getMemberId(), createRequest ,imageUrl);
@@ -52,11 +51,10 @@ public class ProjectController {
             @Auth final Accessor accessor,
             @PathVariable(name = "projectId") final Long projectId,
             @RequestPart(value = "dto") @Valid final ProjectCreateBodyRequest createRequest,
-            @RequestPart(value = "files", required = false) final List<MultipartFile> images
+            @RequestPart(value = "files") final List<MultipartFile> images
             ){
-        log.info("memberId={}의 프로젝트 본문 저장 요청이 들어왔습니다.", accessor.getMemberId());
+        log.info("memberId={}의 projectId={} 본문 저장 요청이 들어왔습니다.", accessor.getMemberId(), projectId);
         projectService.validateProjectByMemberAndProjectStatus(accessor.getMemberId(), projectId, NOT_COMPLETED);
-        // todo: images가 false인 경우
         final List<String> imageUrlList = imageService.saveImages(images);
         projectService.saveProjectBody(accessor.getMemberId(), projectId, createRequest, imageUrlList);
         return ResponseEntity.created(URI.create("/projects/" + projectId)).build();
@@ -68,7 +66,7 @@ public class ProjectController {
             @Auth final Accessor accessor,
             @PathVariable final Long projectId
     ){
-        log.info("memberId={}의 프로젝트 개요 조회 요청이 들어왔습니다.", accessor.getMemberId());
+        log.info("memberId={}의 projectId={}의 개요 조회 요청이 들어왔습니다.", accessor.getMemberId(), projectId);
         projectService.validateProjectByMemberAndProjectStatus(accessor.getMemberId(), projectId, NOT_COMPLETED);
         final ProjectOutlineResponse projectOutlineResponse = projectService.getProjectOutline(projectId);
         return ResponseEntity.ok().body(projectOutlineResponse);
@@ -80,9 +78,9 @@ public class ProjectController {
             @Auth final Accessor accessor,
             @PathVariable final Long projectId,
             @RequestPart(value = "dto") @Valid final ProjectUpdateOutlineRequest updateRequest,
-            @RequestPart(value = "file") final MultipartFile mainImage
+            @RequestPart(value = "file", required = false) final MultipartFile mainImage
     ){
-        log.info("memberId={}의 프로젝트 개요 수정 요청이 들어왔습니다.", accessor.getMemberId());
+        log.info("memberId={}의 projectId={}의 개요 수정 요청이 들어왔습니다.", accessor.getMemberId(), projectId);
         projectService.validateProjectByMemberAndProjectStatus(accessor.getMemberId(), projectId, NOT_COMPLETED);
 
         String imageUrl = null;
@@ -101,7 +99,7 @@ public class ProjectController {
             @Auth final Accessor accessor,
             @PathVariable final Long projectId
     ){
-        log.info("memberId={}의 프로젝트 본문 조회 요청이 들어왔습니다.", accessor.getMemberId());
+        log.info("memberId={}의 projectId={} 본문 조회 요청이 들어왔습니다.", accessor.getMemberId(), projectId);
         projectService.validateProjectByMemberAndProjectStatus(accessor.getMemberId(), projectId, NOT_COMPLETED);
         final ProjectBodyResponse projectBodyResponse = projectService.getProjectBody(projectId);
         return ResponseEntity.ok().body(projectBodyResponse);
@@ -115,7 +113,7 @@ public class ProjectController {
             @RequestPart(value = "dto") @Valid final ProjectUpdateBodyRequest updateRequest,
             @RequestPart(value = "files", required = false) final List<MultipartFile> images
     ){
-        log.info("memberId={}의 프로젝트 본문 수정 요청이 들어왔습니다.", accessor.getMemberId());
+        log.info("memberId={}의 projectId={} 본문 수정 요청이 들어왔습니다.", accessor.getMemberId(), projectId);
         projectService.validateProjectByMemberAndProjectStatus(accessor.getMemberId(), projectId, NOT_COMPLETED);
 
         List<String> imageUrlList = null;
@@ -135,7 +133,7 @@ public class ProjectController {
             @RequestPart(value = "dto") @Valid final ProjectUpdateBodyRequest updateRequest,
             @RequestPart(value = "files", required = false) final List<MultipartFile> images
     ){
-        log.info("memberId={}의 프로젝트 등록 요청이 들어왔습니다.", accessor.getMemberId());
+        log.info("memberId={}의 projectId={} 등록 요청이 들어왔습니다.", accessor.getMemberId(), projectId);
         projectService.validateProjectByMemberAndProjectStatus(accessor.getMemberId(), projectId, NOT_COMPLETED);
 
         List<String> imageUrlList = null;
@@ -155,7 +153,7 @@ public class ProjectController {
             @Auth final Accessor accessor,
             @PathVariable final Long projectId
     ){
-        log.info("memberId={}의 프로젝트 삭제 요청이 들어왔습니다.", accessor.getMemberId());
+        log.info("memberId={}의 projectId={} 삭제 요청이 들어왔습니다.", accessor.getMemberId(), projectId);
         projectService.validateProjectByMember(accessor.getMemberId(), projectId);
         projectService.delete(projectId);
         return ResponseEntity.noContent().build();

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -49,11 +49,11 @@ CREATE TABLE IF NOT EXISTS chat_room (
 CREATE TABLE IF NOT EXISTS project (
     id BIGINT AUTO_INCREMENT,
     member_id BIGINT,
-    summary VARCHAR(20) NOT NULL,
+    summary VARCHAR(30) NOT NULL,
     start_date DATE NOT NULL,
     end_date DATE NOT NULL,
     project_title VARCHAR(50) NOT NULL,
-    main_image_path VARCHAR(255) NOT NULL,
+    main_image_path VARCHAR(100),
     sub_title_list VARCHAR(180),
     content_list VARCHAR(3000),
     project_image_list VARCHAR(1000),

--- a/src/test/java/trackers/demo/note/fixture/NoteFixture.java
+++ b/src/test/java/trackers/demo/note/fixture/NoteFixture.java
@@ -37,6 +37,7 @@ public class NoteFixture {
     );
 
     public static ProjectProposalResponse DUMMY_PROJECT_PROPOSAL = new ProjectProposalResponse(
+            1L,
             "우리사회",
             "환경 오염으로 인한 이상 기후 현상 증가와 그에 대한 경각심 부족",
             "이상 기후 체험 캠페인",

--- a/src/test/java/trackers/demo/note/presentation/NoteControllerTest.java
+++ b/src/test/java/trackers/demo/note/presentation/NoteControllerTest.java
@@ -81,9 +81,9 @@ public class NoteControllerTest extends ControllerTest {
                         .contentType(APPLICATION_JSON));
     }
 
-    private ResultActions performGetProjectProposalRequest() throws Exception {
+    private ResultActions performCreateProjectProposalRequest() throws Exception {
         return mockMvc.perform(
-                RestDocumentationRequestBuilders.get("/note/{noteId}/completion", 1)
+                RestDocumentationRequestBuilders.post("/note/{noteId}/completion", 1)
                         .header(AUTHORIZATION, MEMBER_TOKENS.getAccessToken())
                         .cookie(COOKIE)
                         .contentType(APPLICATION_JSON));
@@ -205,10 +205,10 @@ public class NoteControllerTest extends ControllerTest {
     void getAutomatedProposal() throws Exception {
         // given
         doNothing().when(noteService).validateNoteByMemberId(anyLong(), anyLong());
-        when(noteService.getAutomatedProposal(anyLong())).thenReturn(DUMMY_PROJECT_PROPOSAL);
+        when(noteService.getAutomatedProposal(anyLong(), anyLong())).thenReturn(DUMMY_PROJECT_PROPOSAL);
 
         // when
-        final ResultActions resultActions = performGetProjectProposalRequest();
+        final ResultActions resultActions = performCreateProjectProposalRequest();
 
         // then
         final MvcResult mvcResult = resultActions.andExpect(status().isOk())
@@ -223,6 +223,7 @@ public class NoteControllerTest extends ControllerTest {
                                 parameterWithName("noteId").description("노트 ID")
                         ),
                         responseFields(
+                                fieldWithPath("projectId").type(JsonFieldType.NUMBER).description("프로젝트 ID").attributes(field("constraint", "양의 정수")),
                                 fieldWithPath("target").type(JsonFieldType.STRING).description("대상").attributes(field("constraint", "문자열")),
                                 fieldWithPath("summary").type(JsonFieldType.STRING).description("사회 문제 요약").attributes(field("constraint", "문자열")),
                                 fieldWithPath("projectTitle").type(JsonFieldType.STRING).description("프로젝트 제목").attributes(field("constraint", "문자열")),


### PR DESCRIPTION
### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [✅] 기능 추가
- [ ] 기능 테스트
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 👀 반영 브랜치
ex) feat/project -> dev

### 💻 변경 사항
1. 프로젝트 스키마 변경: mainImage의 NOT NULL 조건 삭제
2. 기획서 자동 완성 시 DB에 저장

### 🙏 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.