### PR TITLE
[feat] 인기 태그 조회 API 추가

### DIFF
--- a/src/docs/asciidoc/docs.adoc
+++ b/src/docs/asciidoc/docs.adoc
@@ -312,6 +312,13 @@ include::{snippets}/gallery-controller-test/get-all-projects-by-tags/query-param
 include::{snippets}/gallery-controller-test/get-all-projects-by-tags/http-response.adoc[]
 include::{snippets}/gallery-controller-test/get-all-projects-by-tags/response-fields.adoc[]
 
+=== 5.5. 인기 태그 조회 ( GET /gallery/tag )
+==== 요청
+include::{snippets}/gallery-controller-test/get-popular-tags/http-request.adoc[]
+==== 응답
+include::{snippets}/gallery-controller-test/get-popular-tags/http-response.adoc[]
+include::{snippets}/gallery-controller-test/get-popular-tags/response-fields.adoc[]
+
 == 6. 응원하기
 
 === 6.1. 프로젝트 좋아요 상태 변경 ( POST /project/:projectId/like )

--- a/src/docs/asciidoc/docs.html
+++ b/src/docs/asciidoc/docs.html
@@ -614,6 +614,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_5_2_프로젝트_갤러리_조회_get_gallery">5.2. 프로젝트 갤러리 조회 ( GET /gallery )</a></li>
 <li><a href="#_5_3_프로젝트_갤러리_키워드로_검색_get_gallerysearchkeyword">5.3. 프로젝트 갤러리 키워드로 검색 ( GET /gallery/search/keyword )</a></li>
 <li><a href="#_5_4_프로젝트_갤러리_태그로_검색_get_gallerysearchtag">5.4. 프로젝트 갤러리 태그로 검색 ( GET /gallery/search/tag )</a></li>
+<li><a href="#_5_5_인기_태그_조회_get_gallerytag">5.5. 인기 태그 조회 ( GET /gallery/tag )</a></li>
 </ul>
 </li>
 <li><a href="#_6_응원하기">6. 응원하기</a>
@@ -4042,6 +4043,58 @@ Content-Length: 800
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_5_5_인기_태그_조회_get_gallerytag"><a class="link" href="#_5_5_인기_태그_조회_get_gallerytag">5.5. 인기 태그 조회 ( GET /gallery/tag )</a></h3>
+<div class="sect3">
+<h4 id="_요청_33"><a class="link" href="#_요청_33">요청</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /gallery/tag HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: accessToken
+Cookie: refresh-token=refreshToken</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_33"><a class="link" href="#_응답_33">응답</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+Content-Length: 185
+
+{
+  "tags" : [ "더나은사회", "열정", "선한 영향력", "지역공동체", "모두의 교육", "기본생활지원", "환경", "인권평화와역사", "어르신", "취업" ]
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>tags[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인기 태그 리스트</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -4050,7 +4103,7 @@ Content-Length: 800
 <div class="sect2">
 <h3 id="_6_1_프로젝트_좋아요_상태_변경_post_projectprojectidlike"><a class="link" href="#_6_1_프로젝트_좋아요_상태_변경_post_projectprojectidlike">6.1. 프로젝트 좋아요 상태 변경 ( POST /project/:projectId/like )</a></h3>
 <div class="sect3">
-<h4 id="_요청_33"><a class="link" href="#_요청_33">요청</a></h4>
+<h4 id="_요청_34"><a class="link" href="#_요청_34">요청</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /project/1/like HTTP/1.1
@@ -4084,7 +4137,7 @@ Cookie: refresh-token=refreshToken
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_33"><a class="link" href="#_응답_33">응답</a></h4>
+<h4 id="_응답_34"><a class="link" href="#_응답_34">응답</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4103,7 +4156,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="sect2">
 <h3 id="_7_1_마이페이지_조회_api_get_mypage"><a class="link" href="#_7_1_마이페이지_조회_api_get_mypage">7.1. 마이페이지 조회 API ( GET /mypage )</a></h3>
 <div class="sect3">
-<h4 id="_요청_34"><a class="link" href="#_요청_34">요청</a></h4>
+<h4 id="_요청_35"><a class="link" href="#_요청_35">요청</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /mypage HTTP/1.1
@@ -4114,7 +4167,7 @@ Cookie: refresh-token=refreshToken</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_응답_34"><a class="link" href="#_응답_34">응답</a></h4>
+<h4 id="_응답_35"><a class="link" href="#_응답_35">응답</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4287,7 +4340,7 @@ Content-Length: 1158
 <div class="sect2">
 <h3 id="_7_2_프로필_수정_api_post_mypageupdate"><a class="link" href="#_7_2_프로필_수정_api_post_mypageupdate">7.2. 프로필 수정 API ( POST /mypage/update )</a></h3>
 <div class="sect3">
-<h4 id="_요청_35"><a class="link" href="#_요청_35">요청</a></h4>
+<h4 id="_요청_36"><a class="link" href="#_요청_36">요청</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /mypage/update HTTP/1.1
@@ -4358,7 +4411,7 @@ Content-Type: multipart/form-data
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_35"><a class="link" href="#_응답_35">응답</a></h4>
+<h4 id="_응답_36"><a class="link" href="#_응답_36">응답</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
@@ -4372,7 +4425,7 @@ Vary: Access-Control-Request-Headers</code></pre>
 <div class="sect2">
 <h3 id="_7_3_내_프로젝트_모두_조회_api_get_mypageproject"><a class="link" href="#_7_3_내_프로젝트_모두_조회_api_get_mypageproject">7.3. 내 프로젝트 모두 조회 API ( GET /mypage/project )</a></h3>
 <div class="sect3">
-<h4 id="_요청_36"><a class="link" href="#_요청_36">요청</a></h4>
+<h4 id="_요청_37"><a class="link" href="#_요청_37">요청</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /mypage/project HTTP/1.1
@@ -4383,7 +4436,7 @@ Cookie: refresh-token=refreshToken</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_응답_36"><a class="link" href="#_응답_36">응답</a></h4>
+<h4 id="_응답_37"><a class="link" href="#_응답_37">응답</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4482,7 +4535,7 @@ Content-Length: 593
 <div class="sect2">
 <h3 id="_7_4_응원한_프로젝트_모두_조회_api_get_mypagelike"><a class="link" href="#_7_4_응원한_프로젝트_모두_조회_api_get_mypagelike">7.4. 응원한 프로젝트 모두 조회 API ( GET /mypage/like )</a></h3>
 <div class="sect3">
-<h4 id="_요청_37"><a class="link" href="#_요청_37">요청</a></h4>
+<h4 id="_요청_38"><a class="link" href="#_요청_38">요청</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /mypage/like HTTP/1.1
@@ -4493,7 +4546,7 @@ Cookie: refresh-token=refreshToken</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_응답_37"><a class="link" href="#_응답_37">응답</a></h4>
+<h4 id="_응답_38"><a class="link" href="#_응답_38">응답</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4559,7 +4612,7 @@ Content-Length: 244
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-11-25 12:49:21 +0900
+Last updated 2024-11-25 15:46:16 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/java/trackers/demo/gallery/domain/repository/CustomProjectTagRepository.java
+++ b/src/main/java/trackers/demo/gallery/domain/repository/CustomProjectTagRepository.java
@@ -1,0 +1,10 @@
+package trackers.demo.gallery.domain.repository;
+
+import trackers.demo.project.domain.Tag;
+
+import java.util.List;
+
+public interface CustomProjectTagRepository {
+
+    List<Tag> findPopularTagsByCount(final int count);
+}

--- a/src/main/java/trackers/demo/gallery/dto/response/TagResponse.java
+++ b/src/main/java/trackers/demo/gallery/dto/response/TagResponse.java
@@ -1,0 +1,19 @@
+package trackers.demo.gallery.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class TagResponse {
+
+    private final List<String> tags;
+
+    public static TagResponse of(final List<String> tags) {
+        return new TagResponse(tags);
+    }
+}

--- a/src/main/java/trackers/demo/gallery/infrastructure/persistence/CustomProjectTagRepositoryImpl.java
+++ b/src/main/java/trackers/demo/gallery/infrastructure/persistence/CustomProjectTagRepositoryImpl.java
@@ -1,0 +1,21 @@
+package trackers.demo.gallery.infrastructure.persistence;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import trackers.demo.gallery.domain.repository.CustomProjectTagRepository;
+import trackers.demo.project.domain.Tag;
+import trackers.demo.project.domain.repository.ProjectTagRepository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomProjectTagRepositoryImpl implements CustomProjectTagRepository {
+
+    private final QuerydslProjectTagRepository querydslProjectTagRepository;
+
+    @Override
+    public List<Tag> findPopularTagsByCount(final int count) {
+        return querydslProjectTagRepository.findPopularTagsByCount(count);
+    }
+}

--- a/src/main/java/trackers/demo/gallery/infrastructure/persistence/QuerydslProjectRepository.java
+++ b/src/main/java/trackers/demo/gallery/infrastructure/persistence/QuerydslProjectRepository.java
@@ -125,7 +125,7 @@ public class QuerydslProjectRepository {
             ).desc();
         }
         if(ProjectSortConditionConsts.RECENT_TIME.equals(order.getProperty())) {
-            return project.createdAt.asc();
+            return project.createdAt.desc();
         }
         if(ProjectSortConditionConsts.CLOSING_TIME.equals(order.getProperty())){
             return project.endDate.asc();

--- a/src/main/java/trackers/demo/gallery/infrastructure/persistence/QuerydslProjectTagRepository.java
+++ b/src/main/java/trackers/demo/gallery/infrastructure/persistence/QuerydslProjectTagRepository.java
@@ -1,0 +1,28 @@
+package trackers.demo.gallery.infrastructure.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import trackers.demo.project.domain.Tag;
+
+import java.util.List;
+
+import static trackers.demo.project.domain.QProjectTag.projectTag;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class QuerydslProjectTagRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<Tag> findPopularTagsByCount(final int count) {
+        return queryFactory.select(projectTag.tag)
+                .from(projectTag)
+                .groupBy(projectTag.tag)
+                .orderBy(projectTag.tag.count().desc())
+                .limit(count)
+                .fetch();
+    }
+}

--- a/src/main/java/trackers/demo/gallery/presentation/GalleryController.java
+++ b/src/main/java/trackers/demo/gallery/presentation/GalleryController.java
@@ -4,23 +4,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import trackers.demo.auth.Auth;
 import trackers.demo.auth.domain.Accessor;
 import trackers.demo.gallery.dto.request.ReadProjectTagCondition;
+import trackers.demo.gallery.dto.response.TagResponse;
 import trackers.demo.gallery.service.GalleryService;
 import trackers.demo.gallery.configuration.DescendingSort;
 import trackers.demo.gallery.dto.request.ReadProjectFilterCondition;
 import trackers.demo.gallery.dto.request.ReadProjectSearchCondition;
 import trackers.demo.gallery.dto.response.ProjectDetailResponse;
 import trackers.demo.gallery.dto.response.ProjectResponse;
-
-import java.util.List;
-
-import static org.springframework.data.domain.Sort.Direction.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,6 +24,13 @@ import static org.springframework.data.domain.Sort.Direction.*;
 public class GalleryController {
 
     private final GalleryService galleryService;
+
+    @GetMapping("/tag")
+    public ResponseEntity<TagResponse> getPopularTags(){
+        log.info("랜덤 태그 조회 요청이 들어왔습니다.");
+        final TagResponse tagResponse = galleryService.getPopularTags();
+        return ResponseEntity.ok(tagResponse);
+    }
 
     @GetMapping
     public ResponseEntity<Page<ProjectResponse>> getAllProjectsByCondition(

--- a/src/main/java/trackers/demo/project/domain/repository/ProjectTagRepository.java
+++ b/src/main/java/trackers/demo/project/domain/repository/ProjectTagRepository.java
@@ -1,5 +1,6 @@
 package trackers.demo.project.domain.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -26,4 +27,5 @@ public interface ProjectTagRepository extends JpaRepository<ProjectTag, Long> {
             """
     )
     void deleteAllByProjectIds(@Param("projectIds") final List<Long> projectIds);
+
 }


### PR DESCRIPTION
### ✅ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [✅] 기능 추가
- [✅] 기능 테스트
- [ ] 기능 삭제
- [✅] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 👀 반영 브랜치
feat/project -> dev

### 💻 변경 사항
- 검색하기 페이지에서 인기 태그 10개를 반환하기 위한 API 추가
- 프로젝트 갤러리에서 최신순 정렬 수정

### 🙏 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.